### PR TITLE
Fix writing multiple arguments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,20 @@
 language: php
 
 php:
-  - 5.5
   - 5.6
   - 7.0
+  - 7.1
   - hhvm
+  - nightly
+
+matrix:
+  allow_failures:
+    - php: nightly
 
 before_script:
-  - wget 'https://github.com/xp-framework/xp-runners/releases/download/v6.4.0/setup' -O - | php
+  - curl -sSL https://dl.bintray.com/xp-runners/generic/xp-run-master.sh > xp-run
   - composer install --prefer-dist
   - echo "vendor/autoload.php" > composer.pth
-  - echo "use=vendor/xp-framework/core" > xp.ini
-  - echo "[runtime]" >> xp.ini
-  - echo "date.timezone=Europe/Berlin" >> xp.ini
 
 script:
-  - ./unittest src/test/php
+  - sh xp-run xp.unittest.TestRunner src/test/php

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ Terminal change log
 
 ## ?.?.? / ????-??-??
 
+* **Heads up: Dropped PHP 5.5 support - now requires PHP 5.6 minimum!**
+  (@thekid)
 * Added compatibility with XP 8 - @thekid
 
 ## 0.3.0 / 2016-07-05

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "keywords": ["module", "xp"],
   "require" : {
     "xp-framework/core": "^8.0 | ^7.0 | ^6.5",
-    "php" : ">=5.5.0"
+    "php" : ">=5.6.0"
   },
   "require-dev" : {
     "xp-framework/unittest": "^7.0 | ^6.5"

--- a/src/main/php/module.xp
+++ b/src/main/php/module.xp
@@ -8,7 +8,7 @@ module xp-forge/term {
   public function initialize() {
     Output::$direct= Console::$out->getStream();
 
-    Console::$out->setStream(new Output(STDOUT));
-    Console::$err->setStream(new Output(STDERR));
+    Console::$out= new Output(Console::$out->getStream());
+    Console::$err= new Output(Console::$err->getStream());
   }
 }

--- a/src/main/php/util/cmd/term/Output.class.php
+++ b/src/main/php/util/cmd/term/Output.class.php
@@ -1,15 +1,103 @@
 <?php namespace util\cmd\term;
 
-class Output extends \io\streams\ConsoleOutputStream {
+use io\streams\OutputStream;
+
+class Output implements \io\streams\OutputStreamWriter {
   public static $direct;
+  private $out= null;
 
   /**
-   * Write a string
+   * Constructor
    *
-   * @param  string $arg
+   * @param  io.streams.OutputStream $out
+   */
+  public function __construct($out) {
+    $this->out= $out;
+  }
+  
+  /**
+   * Return underlying output stream
+   *
+   * @return io.streams.OutputStream
+   */
+  public function getStream() {
+    return $this->out;
+  }
+
+  /**
+   * Return underlying output stream
+   *
+   * @param  io.streams.OutputStream $stream
    * @return void
    */
-  public function write($arg) {
-    parent::write(Terminal::format($arg));
+  public function setStream(OutputStream $stream) {
+    $this->out= $stream;
+  }
+
+  /**
+   * Flush output buffer
+   *
+   * @return void
+   */
+  public function flush() {
+    $this->out->flush();
+  }
+
+  /**
+   * Print arguments
+   *
+   * @param  var... $args
+   * @return void
+   */
+  public function write(... $args) {
+    $r= '';
+    foreach ($args as $arg) {
+      if (is_string($arg)) {
+        $r.= $arg;
+      } else {
+        $r.= \xp::stringOf($arg);
+      }
+    }
+    $this->out->write(Terminal::format($r));
+  }
+
+  /**
+   * Print arguments and append a newline
+   *
+   * @param  var... $args
+   * @return void
+   */
+  public function writeLine(... $args) {
+    $r= '';
+    foreach ($args as $arg) {
+      if (is_string($arg)) {
+        $r.= $arg;
+      } else {
+        $r.= \xp::stringOf($arg);
+      }
+    }
+    $this->out->write(Terminal::format($r."\n"));
+  }
+
+  /**
+   * Print a formatted string
+   *
+   * @param  string $format
+   * @param  var... $args
+   * @return void
+   */
+  public function writef($format, ... $args) {
+    $this->out->write(Terminal::format(vsprintf($format, $args)));
+  }
+
+  /**
+   * Print a formatted string and append a newline
+   *
+   * @param  string $format
+   * @param  var... $args
+   * @return void
+   */
+  public function writeLinef($format, ... $args) {
+    $this->out->write(Terminal::format(vsprintf($format, $args)."\n"));
   }
 }

--- a/src/test/php/util/cmd/term/unittest/ConsoleTest.class.php
+++ b/src/test/php/util/cmd/term/unittest/ConsoleTest.class.php
@@ -1,0 +1,60 @@
+<?php namespace util\cmd\term\unittest;
+
+use util\cmd\Console;
+use io\streams\MemoryOutputStream;
+use util\Bytes;
+
+class ConsoleTest extends \unittest\TestCase {
+
+  /**
+   * Assert formatted input matchs expected outcome
+   *
+   * @param  string $expected
+   * @param  function(): void $block
+   * @throws unittest.AssertionFailedError
+   */
+  private function assertWritten($expected, $block) {
+    $out= Console::$out->getStream();
+    $buffer= new MemoryOutputStream();
+    Console::$out->setStream($buffer);
+
+    try {
+      $block();
+    } finally {
+      Console::$out->setStream($out);
+    }
+
+    $formatted= $buffer->getBytes();
+    if ($expected !== $formatted) {
+      $this->fail('equals', new Bytes($formatted), new Bytes($expected));
+    }
+  }
+
+  #[@test]
+  public function write() {
+    $this->assertWritten("\e[31;1mTest\e[22;39m", function() {
+      Console::write('<red>Test</>');
+    });
+  }
+
+  #[@test]
+  public function write_multiple_args() {
+    $this->assertWritten("\e[31;1mTest\e[22;39m", function() {
+      Console::write('<red>', 'Test', '</>');
+    });
+  }
+
+  #[@test]
+  public function writeLine() {
+    $this->assertWritten("\e[31;1mTest\e[22;39m\n", function() {
+      Console::writeLine('<red>Test</>');
+    });
+  }
+
+  #[@test]
+  public function writeLine_multiple_args() {
+    $this->assertWritten("\e[31;1mTest\e[22;39m\n", function() {
+      Console::writeLine('<red>', 'Test', '</>');
+    });
+  }
+}


### PR DESCRIPTION
Happens when using Console integration.

Before - note the color does not correctly terminate:
![before](https://cloud.githubusercontent.com/assets/696742/18233740/6d8cc208-72ef-11e6-8edc-aba75e9f8b7a.png)

After:
![after](https://cloud.githubusercontent.com/assets/696742/18233742/72c9871a-72ef-11e6-9047-03163264cd22.png)
